### PR TITLE
docs: add npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Themthem is a library of tools which lets you manage your CSS variables and toke
 ## Install
 
 ```shell
+npm install --save themthem
+```
+
+or using yarn
+
+```shell
 yarn add themthem
 ```
 


### PR DESCRIPTION
As npm is the most commonly used package manager in the JS environment, I've added an install line for npm users in the Readme.md.

I've thought about adding a pnpm one too but wasn't sure that it made sense