### PR TITLE
feat: rework public api

### DIFF
--- a/src/css-variable-generator.test.ts
+++ b/src/css-variable-generator.test.ts
@@ -1,8 +1,8 @@
+import { describe, it, expect } from 'vitest';
 import {
-  createCSSVariableGenerator,
+  createCSSVariablesGenerator,
   generateGlobalCSSVariables,
 } from './css-variable-generator';
-import { describe, it, expect } from 'vitest';
 
 interface TestThemthem {
   global: {
@@ -32,12 +32,12 @@ describe('generateGlobalCSSVariables', () => {
 
 describe('createCSSVariableGenerator', () => {
   it('should return a function', () => {
-    const result = createCSSVariableGenerator<'Foo', TestThemthem>('Foo');
+    const result = createCSSVariablesGenerator<'Foo', TestThemthem>('Foo');
     expect(result).toBeInstanceOf(Function);
   });
 
   it('should returns an array of css variable affections', () => {
-    const generateCSSVariables = createCSSVariableGenerator<
+    const generateCSSVariables = createCSSVariablesGenerator<
       'Foo',
       TestThemthem
     >('Foo');

--- a/src/css-variable-generator.test.ts
+++ b/src/css-variable-generator.test.ts
@@ -1,0 +1,51 @@
+import {
+  createCSSVariableGenerator,
+  generateGlobalCSSVariables,
+} from './css-variable-generator';
+import { describe, it, expect } from 'vitest';
+
+interface TestThemthem {
+  global: {
+    foo: ['bar'];
+    bar: ['baz'];
+  };
+  component: {
+    Foo: ['bar'];
+    Baz: ['baz'];
+  };
+}
+
+describe('generateGlobalCSSVariables', () => {
+  it('should returns an array of css variable affections', () => {
+    expect(
+      generateGlobalCSSVariables<TestThemthem>({
+        foo: {
+          bar: 'value',
+        },
+        bar: {
+          baz: 'other-value',
+        },
+      }),
+    ).toEqual(['--global-foo-bar: value;', '--global-bar-baz: other-value;']);
+  });
+});
+
+describe('createCSSVariableGenerator', () => {
+  it('should return a function', () => {
+    const result = createCSSVariableGenerator<'Foo', TestThemthem>('Foo');
+    expect(result).toBeInstanceOf(Function);
+  });
+
+  it('should returns an array of css variable affections', () => {
+    const generateCSSVariables = createCSSVariableGenerator<
+      'Foo',
+      TestThemthem
+    >('Foo');
+
+    expect(
+      generateCSSVariables({
+        bar: 'value',
+      }),
+    ).toEqual(['--Foo-bar: value;']);
+  });
+});

--- a/src/css-variable-generator.ts
+++ b/src/css-variable-generator.ts
@@ -1,21 +1,22 @@
 import type { DTBoxKey, DesignToken, Themthem } from './token-box';
-import { cssToken } from './helpers';
+import { cssVariable } from './helpers';
 import { getKeys } from './utils';
 
-export function createCSSVariableGenerator<
-  C extends DTBoxKey<'component', T> & string,
-  T extends Themthem = Themthem,
->(component: C) {
+export function createCSSVariablesGenerator<
+  Key extends DTBoxKey<'component', ThemeInterface> & string,
+  ThemeInterface extends Themthem = Themthem,
+>(component: Key) {
   return function generateCSSVariables(config: {
-    [K in DesignToken<'component', C, T>]+?: string;
+    [Token in DesignToken<'component', Key, ThemeInterface>]+?: string;
   }) {
     const variables: string[] = [];
     for (const key of getKeys(config)) {
       variables.push(
-        `${cssToken<'component', C, typeof key, T>(
+        `${cssVariable<'component', Key, typeof key, ThemeInterface>(
           'component',
           component,
           key,
+          { bare: true },
         )}: ${config[key]};`,
       );
     }
@@ -24,10 +25,10 @@ export function createCSSVariableGenerator<
 }
 
 export function generateGlobalCSSVariables<
-  T extends Themthem = Themthem,
+  ThemeInterface extends Themthem = Themthem,
 >(config: {
-  [K in DTBoxKey<'global', T> & string]+?: {
-    [TK in DesignToken<'global', K, T>]+?: string;
+  [Key in DTBoxKey<'global', ThemeInterface> & string]+?: {
+    [Token in DesignToken<'global', Key, ThemeInterface>]+?: string;
   };
 }) {
   const variables: string[] = [];
@@ -36,7 +37,9 @@ export function generateGlobalCSSVariables<
     for (const token of getKeys(configValue)) {
       const variable = configValue[token];
       variables.push(
-        `${cssToken('global', key as never, token as never)}: ${variable};`,
+        `${cssVariable('global', key as never, token as never, {
+          bare: true,
+        })}: ${variable};`,
       );
     }
   }

--- a/src/css-variable-generator.ts
+++ b/src/css-variable-generator.ts
@@ -3,7 +3,7 @@ import { cssToken } from './helpers';
 import { getKeys } from './utils';
 
 export function createCSSVariableGenerator<
-  C extends DTBoxKey<'component'>,
+  C extends DTBoxKey<'component', T> & string,
   T extends Themthem = Themthem,
 >(component: C) {
   return function generateCSSVariables(config: {
@@ -12,7 +12,11 @@ export function createCSSVariableGenerator<
     const variables: string[] = [];
     for (const key of getKeys(config)) {
       variables.push(
-        `${cssToken('component', component, key)}: ${config[key]};`,
+        `${cssToken<'component', C, typeof key, T>(
+          'component',
+          component,
+          key,
+        )}: ${config[key]};`,
       );
     }
     return variables;
@@ -22,7 +26,7 @@ export function createCSSVariableGenerator<
 export function generateGlobalCSSVariables<
   T extends Themthem = Themthem,
 >(config: {
-  [K in DTBoxKey<'global', T>]+?: {
+  [K in DTBoxKey<'global', T> & string]+?: {
     [TK in DesignToken<'global', K, T>]+?: string;
   };
 }) {

--- a/src/css-variable-generator.ts
+++ b/src/css-variable-generator.ts
@@ -1,75 +1,18 @@
-/// <reference path="../interfaces.d.ts" />
-
-import type { TokenBoxKey, Token } from './token-box';
-import type { ThemthemVariable } from './helpers';
+import type { DTBoxKey, DesignToken, Themthem } from './token-box';
 import { cssToken } from './helpers';
 import { getKeys } from './utils';
 
-type GDT = GlobalDesignTokenBox;
-type CDT = ComponentDesignTokenBox;
-
-export type Source<C extends keyof GDT | keyof CDT> = C extends keyof GDT
-  ? GDT[C]
-  : C extends keyof CDT
-  ? CDT[C]
-  : never;
-
-export type Tuple<
-  C extends keyof GDT | keyof CDT = keyof GDT | keyof CDT,
-  T extends Source<C>[number] = Source<C>[number],
-> = [C, T];
-
-export type ExtractVariable<T extends Tuple> = T extends Tuple<
-  infer C,
-  infer CT
->
-  ? C extends TokenBoxKey<'global'>
-    ? CT extends Token<'global', C>
-      ? ThemthemVariable<'global', C, CT>
-      : never
-    : C extends TokenBoxKey<'component'>
-    ? CT extends Token<'component', C>
-      ? ThemthemVariable<'component', C, CT>
-      : never
-    : never
-  : never;
-
-export type ConfigTuple<K extends string = string, T extends Tuple = Tuple> = [
-  K,
-  T,
-];
-
-export type Merge<T> = { [K in keyof T]: T[K] };
-
-export type TupleToObject<T extends ConfigTuple> = T extends ConfigTuple<
-  infer K,
-  infer F
->
-  ? { [P in K]: ExtractVariable<F> }
-  : never;
-
-export type Config<
-  C extends TokenBoxKey<'component'>,
-  T extends ConfigTuple<Token<'component', C>>[],
-> = T extends [infer F extends ConfigTuple]
-  ? TupleToObject<F>
-  : T extends [
-      infer F extends ConfigTuple,
-      ...infer Rest extends ConfigTuple<Token<'component', C>>[],
-    ]
-  ? Merge<TupleToObject<F> & Config<C, Rest>>
-  : never;
-
-export function createCSSVariableGenerator<C extends TokenBoxKey<'component'>>(
-  component: C,
-) {
-  return function generateCSSVariables<CC extends Config<C, any>>(config: CC) {
+export function createCSSVariableGenerator<
+  C extends DTBoxKey<'component'>,
+  T extends Themthem = Themthem,
+>(component: C) {
+  return function generateCSSVariables(config: {
+    [K in DesignToken<'component', C, T>]+?: string;
+  }) {
     const variables: string[] = [];
     for (const key of getKeys(config)) {
       variables.push(
-        `${cssToken('component', component, key as Token<'component', C>)}: ${
-          config[key]
-        };`,
+        `${cssToken('component', component, key)}: ${config[key]};`,
       );
     }
     return variables;
@@ -77,20 +20,19 @@ export function createCSSVariableGenerator<C extends TokenBoxKey<'component'>>(
 }
 
 export function generateGlobalCSSVariables<
-  K extends TokenBoxKey<'global'>,
-  T extends Token<'global', K>,
+  T extends Themthem = Themthem,
 >(config: {
-  [k in K]: {
-    [t in T]: string;
+  [K in DTBoxKey<'global', T>]+?: {
+    [TK in DesignToken<'global', K, T>]+?: string;
   };
 }) {
   const variables: string[] = [];
   for (const key of getKeys(config)) {
-    for (const token of getKeys(config[key])) {
+    const configValue = config[key]!;
+    for (const token of getKeys(configValue)) {
+      const variable = configValue[token];
       variables.push(
-        `${cssToken('global', key, token as Token<K, T>)}: ${
-          config[key][token]
-        };`,
+        `${cssToken('global', key as never, token as never)}: ${variable};`,
       );
     }
   }

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { cssVariable } from './helpers';
+
+interface TestThemthem {
+  global: {
+    foo: ['bar'];
+    bar: ['baz'];
+  };
+  component: {
+    Foo: ['bar'];
+    Baz: ['baz'];
+  };
+}
+
+describe('cssVariable', () => {
+  it('should print the css variable usage by default', () => {
+    expect(
+      cssVariable<'global', 'foo', 'bar', TestThemthem>('global', 'foo', 'bar'),
+    ).toBe('var(--global-foo-bar)');
+    expect(
+      cssVariable<'global', 'foo', 'bar', TestThemthem>(
+        'global',
+        'foo',
+        'bar',
+        {},
+      ),
+    ).toBe('var(--global-foo-bar)');
+    expect(
+      cssVariable<'global', 'foo', 'bar', TestThemthem>(
+        'global',
+        'foo',
+        'bar',
+        { bare: false },
+      ),
+    ).toBe('var(--global-foo-bar)');
+  });
+
+  it('should print the bare css variable when bare options is true', () => {
+    expect(
+      cssVariable<'global', 'foo', 'bar', TestThemthem>(
+        'global',
+        'foo',
+        'bar',
+        { bare: true },
+      ),
+    ).toBe('--global-foo-bar');
+  });
+});

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,31 +1,35 @@
-import { DTBoxType, DTBoxKey, DesignToken } from './token-box';
+import { DTBoxType, DTBoxKey, DesignToken, Themthem } from './token-box';
 
 export type ThemthemToken<
-  Type extends DTBoxType,
-  K extends DTBoxKey<Type> & string,
-  TToken extends DesignToken<Type, K>,
-> = Type extends 'global' ? `--global-${K}-${TToken}` : `--${K}-${TToken}`;
+  TType extends DTBoxType<T>,
+  K extends DTBoxKey<TType, T> & string,
+  TToken extends DesignToken<TType, K, T>,
+  T extends Themthem = Themthem,
+> = TType extends 'global' ? `--global-${K}-${TToken}` : `--${K}-${TToken}`;
 
 export type ThemthemVariable<
-  Type extends DTBoxType,
-  K extends DTBoxKey<Type> & string,
-  TToken extends DesignToken<Type, K>,
-> = `var(${ThemthemToken<Type, K, TToken>})`;
+  TType extends DTBoxType<T>,
+  K extends DTBoxKey<TType, T> & string,
+  TToken extends DesignToken<TType, K, T>,
+  T extends Themthem = Themthem,
+> = `var(${ThemthemToken<TType, K, TToken, T>})`;
 
 export function cssToken<
-  Type extends DTBoxType,
-  K extends DTBoxKey<Type> & string,
-  TToken extends DesignToken<Type, K>,
->(type: Type, key: K, token: TToken): ThemthemToken<Type, K, TToken> {
+  TType extends DTBoxType<T>,
+  K extends DTBoxKey<TType, T> & string,
+  TToken extends DesignToken<TType, K, T>,
+  T extends Themthem = Themthem,
+>(type: TType, key: K, token: TToken): ThemthemToken<TType, K, TToken, T> {
   return (
     type === 'global' ? `--global-${key}-${token}` : `--${key}-${token}`
-  ) as ThemthemToken<Type, K, TToken>;
+  ) as ThemthemToken<TType, K, TToken, T>;
 }
 
 export function cssVariable<
-  Type extends DTBoxType,
-  K extends DTBoxKey<Type> & string,
-  TToken extends DesignToken<Type, K>,
->(type: Type, key: K, token: TToken): ThemthemVariable<Type, K, TToken> {
-  return `var(${cssToken(type, key, token)})`;
+  TType extends DTBoxType<T>,
+  K extends DTBoxKey<TType, T> & string,
+  TToken extends DesignToken<TType, K, T>,
+  T extends Themthem = Themthem,
+>(type: TType, key: K, token: TToken): ThemthemVariable<TType, K, TToken, T> {
+  return `var(${cssToken<TType, K, TToken, T>(type, key, token)})`;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,35 +1,57 @@
 import { DTBoxType, DTBoxKey, DesignToken, Themthem } from './token-box';
 
-export type ThemthemToken<
-  TType extends DTBoxType<T>,
-  K extends DTBoxKey<TType, T> & string,
-  TToken extends DesignToken<TType, K, T>,
-  T extends Themthem = Themthem,
-> = TType extends 'global' ? `--global-${K}-${TToken}` : `--${K}-${TToken}`;
-
 export type ThemthemVariable<
-  TType extends DTBoxType<T>,
-  K extends DTBoxKey<TType, T> & string,
-  TToken extends DesignToken<TType, K, T>,
-  T extends Themthem = Themthem,
-> = `var(${ThemthemToken<TType, K, TToken, T>})`;
+  Type extends DTBoxType<ThemeInterface>,
+  Key extends DTBoxKey<Type, ThemeInterface> & string,
+  Token extends DesignToken<Type, Key, ThemeInterface>,
+  ThemeInterface extends Themthem = Themthem,
+> = Type extends 'global' ? `--global-${Key}-${Token}` : `--${Key}-${Token}`;
 
-export function cssToken<
-  TType extends DTBoxType<T>,
-  K extends DTBoxKey<TType, T> & string,
-  TToken extends DesignToken<TType, K, T>,
-  T extends Themthem = Themthem,
->(type: TType, key: K, token: TToken): ThemthemToken<TType, K, TToken, T> {
-  return (
-    type === 'global' ? `--global-${key}-${token}` : `--${key}-${token}`
-  ) as ThemthemToken<TType, K, TToken, T>;
-}
+export type ThemthemVariableUsage<
+  Type extends DTBoxType<ThemeInterface>,
+  Key extends DTBoxKey<Type, ThemeInterface> & string,
+  Token extends DesignToken<Type, Key, ThemeInterface>,
+  ThemeInterface extends Themthem = Themthem,
+> = `var(${ThemthemVariable<Type, Key, Token, ThemeInterface>})`;
 
 export function cssVariable<
-  TType extends DTBoxType<T>,
-  K extends DTBoxKey<TType, T> & string,
-  TToken extends DesignToken<TType, K, T>,
-  T extends Themthem = Themthem,
->(type: TType, key: K, token: TToken): ThemthemVariable<TType, K, TToken, T> {
-  return `var(${cssToken<TType, K, TToken, T>(type, key, token)})`;
+  Type extends DTBoxType<ThemeInterface>,
+  Key extends DTBoxKey<Type, ThemeInterface> & string,
+  Token extends DesignToken<Type, Key, ThemeInterface>,
+  ThemeInterface extends Themthem = Themthem,
+>(
+  type: Type,
+  key: Key,
+  token: Token,
+  options: { bare: true },
+): ThemthemVariable<Type, Key, Token, ThemeInterface>;
+export function cssVariable<
+  Type extends DTBoxType<ThemeInterface>,
+  Key extends DTBoxKey<Type, ThemeInterface> & string,
+  Token extends DesignToken<Type, Key, ThemeInterface>,
+  ThemeInterface extends Themthem = Themthem,
+>(
+  type: Type,
+  key: Key,
+  token: Token,
+  options?: { bare?: false },
+): ThemthemVariableUsage<Type, Key, Token, ThemeInterface>;
+export function cssVariable<
+  Type extends DTBoxType<ThemeInterface>,
+  Key extends DTBoxKey<Type, ThemeInterface> & string,
+  Token extends DesignToken<Type, Key, ThemeInterface>,
+  ThemeInterface extends Themthem = Themthem,
+>(
+  type: Type,
+  key: Key,
+  token: Token,
+  { bare = false }: { bare?: boolean } = {},
+):
+  | ThemthemVariable<Type, Key, Token, ThemeInterface>
+  | ThemthemVariableUsage<Type, Key, Token, ThemeInterface> {
+  const variable = (
+    type === 'global' ? `--global-${key}-${token}` : `--${key}-${token}`
+  ) as ThemthemVariable<Type, Key, Token, ThemeInterface>;
+
+  return bare ? variable : `var(${variable})`;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,21 +1,21 @@
-import { TokenType, TokenBoxKey, Token } from './token-box';
+import { DTBoxType, DTBoxKey, DesignToken } from './token-box';
 
 export type ThemthemToken<
-  Type extends TokenType,
-  K extends TokenBoxKey<Type> & string,
-  TToken extends Token<Type, K>,
+  Type extends DTBoxType,
+  K extends DTBoxKey<Type> & string,
+  TToken extends DesignToken<Type, K>,
 > = Type extends 'global' ? `--global-${K}-${TToken}` : `--${K}-${TToken}`;
 
 export type ThemthemVariable<
-  Type extends TokenType,
-  K extends TokenBoxKey<Type> & string,
-  TToken extends Token<Type, K>,
+  Type extends DTBoxType,
+  K extends DTBoxKey<Type> & string,
+  TToken extends DesignToken<Type, K>,
 > = `var(${ThemthemToken<Type, K, TToken>})`;
 
 export function cssToken<
-  Type extends TokenType,
-  K extends TokenBoxKey<Type> & string,
-  TToken extends Token<Type, K>,
+  Type extends DTBoxType,
+  K extends DTBoxKey<Type> & string,
+  TToken extends DesignToken<Type, K>,
 >(type: Type, key: K, token: TToken): ThemthemToken<Type, K, TToken> {
   return (
     type === 'global' ? `--global-${key}-${token}` : `--${key}-${token}`
@@ -23,9 +23,9 @@ export function cssToken<
 }
 
 export function cssVariable<
-  Type extends TokenType,
-  K extends TokenBoxKey<Type> & string,
-  TToken extends Token<Type, K>,
+  Type extends DTBoxType,
+  K extends DTBoxKey<Type> & string,
+  TToken extends DesignToken<Type, K>,
 >(type: Type, key: K, token: TToken): ThemthemVariable<Type, K, TToken> {
   return `var(${cssToken(type, key, token)})`;
 }

--- a/src/token-box.ts
+++ b/src/token-box.ts
@@ -5,18 +5,28 @@ export interface Themthem {
   component: ComponentDesignTokenBox;
 }
 
-export type TokenType = keyof Themthem;
+export type DTBoxType<T extends Themthem = Themthem> = keyof T;
 
-export type TokenBox<T extends TokenType> = Themthem[T];
-export type TokenBoxKey<T extends TokenType> = keyof TokenBox<T>;
+export type DTBox<
+  TType extends DTBoxType<T>,
+  T extends Themthem = Themthem,
+> = T[TType];
 
-export type Tokens<
-  T extends TokenType,
-  C extends TokenBoxKey<T>,
-> = TokenBox<T>[C];
-export type Token<T extends TokenType, C extends TokenBoxKey<T>> = Tokens<
-  T,
-  C
-> extends string[]
-  ? Tokens<T, C>[number]
+export type DTBoxKey<
+  TType extends DTBoxType<T>,
+  T extends Themthem = Themthem,
+> = keyof DTBox<TType, T>;
+
+export type DesignTokens<
+  TType extends DTBoxType<T>,
+  C extends DTBoxKey<TType, T>,
+  T extends Themthem = Themthem,
+> = DTBox<TType, T>[C];
+
+export type DesignToken<
+  TType extends DTBoxType<T>,
+  C extends DTBoxKey<TType, T>,
+  T extends Themthem = Themthem,
+> = DesignTokens<TType, C, T> extends string[]
+  ? DesignTokens<TType, C, T>[number]
   : never;

--- a/src/token-box.ts
+++ b/src/token-box.ts
@@ -5,28 +5,29 @@ export interface Themthem {
   component: ComponentDesignTokenBox;
 }
 
-export type DTBoxType<T extends Themthem = Themthem> = keyof T;
+export type DTBoxType<ThemeInterface extends Themthem = Themthem> =
+  keyof ThemeInterface;
 
 export type DTBox<
-  TType extends DTBoxType<T>,
-  T extends Themthem = Themthem,
-> = T[TType];
+  Type extends DTBoxType<ThemeInterface>,
+  ThemeInterface extends Themthem = Themthem,
+> = ThemeInterface[Type];
 
 export type DTBoxKey<
-  TType extends DTBoxType<T>,
-  T extends Themthem = Themthem,
-> = keyof DTBox<TType, T>;
+  Type extends DTBoxType<ThemeInterface>,
+  ThemeInterface extends Themthem = Themthem,
+> = keyof DTBox<Type, ThemeInterface>;
 
 export type DesignTokens<
-  TType extends DTBoxType<T>,
-  C extends DTBoxKey<TType, T>,
-  T extends Themthem = Themthem,
-> = DTBox<TType, T>[C];
+  Type extends DTBoxType<ThemeInterface>,
+  Key extends DTBoxKey<Type, ThemeInterface>,
+  ThemeInterface extends Themthem = Themthem,
+> = DTBox<Type, ThemeInterface>[Key];
 
 export type DesignToken<
-  TType extends DTBoxType<T>,
-  C extends DTBoxKey<TType, T>,
-  T extends Themthem = Themthem,
-> = DesignTokens<TType, C, T> extends string[]
-  ? DesignTokens<TType, C, T>[number]
+  Type extends DTBoxType<ThemeInterface>,
+  Key extends DTBoxKey<Type, ThemeInterface>,
+  ThemeInterface extends Themthem = Themthem,
+> = DesignTokens<Type, Key, ThemeInterface> extends string[]
+  ? DesignTokens<Type, Key, ThemeInterface>[number]
   : never;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,5 @@
+/// <reference types="vitest" />
+
 import { defineConfig } from 'vite';
 
 export default defineConfig({


### PR DESCRIPTION
- `cssToken` and `cssVariable` has been merged into one function `cssVariable` which now takes a fourth parameter: `options`.
  - If `options.bare` is not specified or `false`, the output will be the usage of the css variable (for example, `var(--global-category-token)`)
  - If `options.bare` is `true`, the output will be the bare css variable (for example, `--global-category-token`)
- renamed `createCSSVariableGenerator` to `createCSSVariablesGenerator`